### PR TITLE
Migrations and models improved

### DIFF
--- a/app/models/rim.rb
+++ b/app/models/rim.rb
@@ -3,17 +3,18 @@
 # Table name: rims
 #
 #  id         :bigint           not null, primary key
-#  wheel_id   :bigint           not null
+#  wheel_id   :bigint
 #  color      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  size       :integer
 #
 # Indexes
 #
 #  index_rims_on_wheel_id  (wheel_id)
 #
 class Rim < ApplicationRecord
-  belongs_to :wheel
+  belongs_to :wheel, optional: true
 
-  validates :color, presence: true
+  validates :color, :size, presence: true
 end

--- a/app/models/saddle.rb
+++ b/app/models/saddle.rb
@@ -3,7 +3,7 @@
 # Table name: saddles
 #
 #  id         :bigint           not null, primary key
-#  bicycle_id :bigint           not null
+#  bicycle_id :bigint
 #  color      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -13,7 +13,7 @@
 #  index_saddles_on_bicycle_id  (bicycle_id)
 #
 class Saddle < ApplicationRecord
-  belongs_to :bicycle
+  belongs_to :bicycle, optional: true
 
   validates :color, presence: true
 end

--- a/app/models/wheel.rb
+++ b/app/models/wheel.rb
@@ -3,7 +3,7 @@
 # Table name: wheels
 #
 #  id         :bigint           not null, primary key
-#  bicycle_id :bigint           not null
+#  bicycle_id :bigint
 #  size       :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -11,11 +11,11 @@
 # Indexes
 #
 #  index_wheels_on_bicycle_id  (bicycle_id)
-#  index_wheels_on_size        (size) UNIQUE
+#  index_wheels_on_size        (size)
 #
 class Wheel < ApplicationRecord
-  belongs_to :bicycle
+  belongs_to :bicycle, optional: true
   has_one :rim, dependent: :destroy
 
-  validates :size, uniqueness: true, presence: true
+  validates :size, presence: true
 end

--- a/db/migrate/20210523220397_create_bicycles.rb
+++ b/db/migrate/20210523220397_create_bicycles.rb
@@ -1,5 +1,9 @@
 class CreateBicycles < ActiveRecord::Migration[6.1]
-  def change
+  def up
     create_table(:bicycles, &:timestamps)
+  end
+
+  def down
+    drop_table(:bicycles)
   end
 end

--- a/db/migrate/20210523220400_create_wheels.rb
+++ b/db/migrate/20210523220400_create_wheels.rb
@@ -1,5 +1,5 @@
 class CreateWheels < ActiveRecord::Migration[6.1]
-  def change
+  def up
     create_table :wheels do |t|
       t.references :bicycle, null: false
       t.integer :size
@@ -7,5 +7,9 @@ class CreateWheels < ActiveRecord::Migration[6.1]
       t.timestamps
     end
     add_index :wheels, :size, unique: true
+  end
+
+  def down
+    drop_table(:wheels)
   end
 end

--- a/db/migrate/20210523220405_create_rims.rb
+++ b/db/migrate/20210523220405_create_rims.rb
@@ -1,10 +1,14 @@
 class CreateRims < ActiveRecord::Migration[6.1]
-  def change
+  def up
     create_table :rims do |t|
       t.references :wheel, null: false
       t.string :color
 
       t.timestamps
     end
+  end
+
+  def down
+    drop_table(:rims)
   end
 end

--- a/db/migrate/20210523220419_create_saddles.rb
+++ b/db/migrate/20210523220419_create_saddles.rb
@@ -7,4 +7,8 @@ class CreateSaddles < ActiveRecord::Migration[6.1]
       t.timestamps
     end
   end
+
+  def down
+    drop_table(:saddles)
+  end
 end

--- a/db/migrate/20210525191039_add_size_to_rims.rb
+++ b/db/migrate/20210525191039_add_size_to_rims.rb
@@ -1,0 +1,9 @@
+class AddSizeToRims < ActiveRecord::Migration[6.1]
+  def up
+    add_column :rims, :size, :integer
+  end
+
+  def down
+    remove_column :rims, :size
+  end
+end

--- a/db/migrate/20210525191624_change_columns_from_not_nullable_to_nullable.rb
+++ b/db/migrate/20210525191624_change_columns_from_not_nullable_to_nullable.rb
@@ -1,0 +1,13 @@
+class ChangeColumnsFromNotNullableToNullable < ActiveRecord::Migration[6.1]
+  def up
+    change_column :wheels, :bicycle_id, :bigint, null: true
+    change_column :saddles, :bicycle_id, :bigint, null: true
+    change_column :rims, :wheel_id, :bigint, null: true
+  end
+
+  def down
+    change_column :wheels, :bicycle_id, :bigint, null: false
+    change_column :saddles, :bicycle_id, :bigint, null: false
+    change_column :rims, :wheel_id, :bigint, null: false
+  end
+end

--- a/db/migrate/20210525191913_update_wheels_size_index.rb
+++ b/db/migrate/20210525191913_update_wheels_size_index.rb
@@ -1,0 +1,11 @@
+class UpdateWheelsSizeIndex < ActiveRecord::Migration[6.1]
+  def up
+    remove_index :wheels, :size, unique: true
+    add_index :wheels, :size
+  end
+
+  def down
+    remove_index :wheels, :size
+    add_index :wheels, :size, unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -96,10 +96,11 @@ ALTER SEQUENCE public.bicycles_id_seq OWNED BY public.bicycles.id;
 
 CREATE TABLE public.rims (
     id bigint NOT NULL,
-    wheel_id bigint NOT NULL,
+    wheel_id bigint,
     color character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    size integer
 );
 
 
@@ -128,7 +129,7 @@ ALTER SEQUENCE public.rims_id_seq OWNED BY public.rims.id;
 
 CREATE TABLE public.saddles (
     id bigint NOT NULL,
-    bicycle_id bigint NOT NULL,
+    bicycle_id bigint,
     color character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -169,7 +170,7 @@ CREATE TABLE public.schema_migrations (
 
 CREATE TABLE public.wheels (
     id bigint NOT NULL,
-    bicycle_id bigint NOT NULL,
+    bicycle_id bigint,
     size integer,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -325,7 +326,7 @@ CREATE INDEX index_wheels_on_bicycle_id ON public.wheels USING btree (bicycle_id
 -- Name: index_wheels_on_size; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_wheels_on_size ON public.wheels USING btree (size);
+CREATE INDEX index_wheels_on_size ON public.wheels USING btree (size);
 
 
 --
@@ -339,6 +340,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210523220397'),
 ('20210523220400'),
 ('20210523220405'),
-('20210523220419');
+('20210523220419'),
+('20210525191039'),
+('20210525191624'),
+('20210525191913');
 
 

--- a/spec/factories/rims.rb
+++ b/spec/factories/rims.rb
@@ -3,10 +3,11 @@
 # Table name: rims
 #
 #  id         :bigint           not null, primary key
-#  wheel_id   :bigint           not null
+#  wheel_id   :bigint
 #  color      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  size       :integer
 #
 # Indexes
 #

--- a/spec/factories/saddles.rb
+++ b/spec/factories/saddles.rb
@@ -3,7 +3,7 @@
 # Table name: saddles
 #
 #  id         :bigint           not null, primary key
-#  bicycle_id :bigint           not null
+#  bicycle_id :bigint
 #  color      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/factories/wheels.rb
+++ b/spec/factories/wheels.rb
@@ -3,7 +3,7 @@
 # Table name: wheels
 #
 #  id         :bigint           not null, primary key
-#  bicycle_id :bigint           not null
+#  bicycle_id :bigint
 #  size       :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -11,7 +11,7 @@
 # Indexes
 #
 #  index_wheels_on_bicycle_id  (bicycle_id)
-#  index_wheels_on_size        (size) UNIQUE
+#  index_wheels_on_size        (size)
 #
 FactoryBot.define do
   factory :wheel do

--- a/spec/models/rim_spec.rb
+++ b/spec/models/rim_spec.rb
@@ -17,10 +17,11 @@ require 'rails_helper'
 
 RSpec.describe Rim, type: :model do
   describe 'associations' do
-    it { is_expected.to belong_to(:wheel) }
+    it { is_expected.to belong_to(:wheel).optional }
   end
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:color) }
+    it { is_expected.to validate_presence_of(:size) }
   end
 end

--- a/spec/models/rim_spec.rb
+++ b/spec/models/rim_spec.rb
@@ -3,10 +3,11 @@
 # Table name: rims
 #
 #  id         :bigint           not null, primary key
-#  wheel_id   :bigint           not null
+#  wheel_id   :bigint
 #  color      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  size       :integer
 #
 # Indexes
 #

--- a/spec/models/saddle_spec.rb
+++ b/spec/models/saddle_spec.rb
@@ -16,7 +16,7 @@ require 'rails_helper'
 
 RSpec.describe Saddle, type: :model do
   describe 'associations' do
-    it { is_expected.to belong_to(:bicycle) }
+    it { is_expected.to belong_to(:bicycle).optional }
   end
 
   describe 'validations' do

--- a/spec/models/saddle_spec.rb
+++ b/spec/models/saddle_spec.rb
@@ -3,7 +3,7 @@
 # Table name: saddles
 #
 #  id         :bigint           not null, primary key
-#  bicycle_id :bigint           not null
+#  bicycle_id :bigint
 #  color      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/models/wheel_spec.rb
+++ b/spec/models/wheel_spec.rb
@@ -3,7 +3,7 @@
 # Table name: wheels
 #
 #  id         :bigint           not null, primary key
-#  bicycle_id :bigint           not null
+#  bicycle_id :bigint
 #  size       :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -11,7 +11,7 @@
 # Indexes
 #
 #  index_wheels_on_bicycle_id  (bicycle_id)
-#  index_wheels_on_size        (size) UNIQUE
+#  index_wheels_on_size        (size)
 #
 require 'rails_helper'
 

--- a/spec/models/wheel_spec.rb
+++ b/spec/models/wheel_spec.rb
@@ -20,11 +20,10 @@ RSpec.describe Wheel, type: :model do
 
   describe 'associations' do
     it { is_expected.to have_one(:rim).dependent(:destroy) }
-    it { is_expected.to belong_to(:bicycle) }
+    it { is_expected.to belong_to(:bicycle).optional }
   end
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:size) }
-    it { expect(subject).to validate_uniqueness_of(:size) }
   end
 end


### PR DESCRIPTION
## Description

It changes the models in a way that every relation is optional so we can do bulk imports of the different parts. Also, adds size column to rims so we can match the size of the wheel with the suitable size of a rim inside a wheel, therefore we can get the available rims for a specific wheel size.
Adds up and down on the migrations.